### PR TITLE
Extraction graph from yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "getindexify",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "This is the TypeScript client for interacting with the Indexify service.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/ExtractionGraph.ts
+++ b/src/ExtractionGraph.ts
@@ -1,0 +1,54 @@
+import { IExtractionPolicy } from "./types";
+import yaml from "yaml";
+
+class ExtractionGraph {
+  id?: string;
+  name: string;
+  namespace?: string;
+  extraction_policies: IExtractionPolicy[];
+
+  constructor({
+    id,
+    name,
+    namespace,
+    extraction_policies,
+  }: {
+    id?: string;
+    name: string;
+    namespace?: string;
+    extraction_policies: IExtractionPolicy[];
+  }) {
+    this.id = id;
+    this.name = name;
+    this.namespace = namespace;
+    this.extraction_policies = extraction_policies;
+  }
+
+  static fromDict(json: Record<string, any>): ExtractionGraph {
+    if ("namespace" in json) {
+      delete json["namespace"];
+    }
+    return new ExtractionGraph({
+      id: json.id,
+      name: json.name,
+      extraction_policies: json.extraction_policies,
+    });
+  }
+
+  static fromYaml(spec: string): ExtractionGraph {
+    const json = yaml.parse(spec);
+    return ExtractionGraph.fromDict(json);
+  }
+
+  toDict(): Record<string, any> {
+    const filteredDict: Record<string, any> = {};
+    for (const key in this) {
+      if (this[key] !== null && this[key] !== undefined) {
+        filteredDict[key] = this[key];
+      }
+    }
+    return filteredDict;
+  }
+}
+
+export default ExtractionGraph;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import ExtractionGraph from "./ExtractionGraph";
 import IndexifyClient from "./client";
 import Extractor from "./extractor";
 import {
@@ -8,7 +9,6 @@ import {
   IIndex,
   IContentMetadata,
   IExtractedMetadata,
-  IExtractionGraph,
   IExtractionPolicy,
   ISearchIndexResponse,
   ITask,
@@ -29,7 +29,7 @@ export {
   IIndex,
   IContentMetadata,
   IExtractedMetadata,
-  IExtractionGraph,
+  ExtractionGraph,
   IExtractionPolicy,
   ISearchIndexResponse,
   ITask,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
+import ExtractionGraph from "./ExtractionGraph";
+
 export interface INamespace {
   name: string;
-  extraction_graphs: IExtractionGraph[];
+  extraction_graphs: ExtractionGraph[];
 }
 
 export interface IEmbeddingSchema {
@@ -64,13 +66,6 @@ export interface IExtractedMetadata {
   extractor_name: string;
 }
 
-export interface IExtractionGraph {
-  id: string;
-  name: string;
-  namespace: string;
-  extraction_policies: IExtractionPolicy[];
-}
-
 export interface IExtractionPolicy {
   id?: string;
   extractor: string;
@@ -78,7 +73,7 @@ export interface IExtractionPolicy {
   labels_eq?: string;
   input_params?: Record<string, string | number>;
   content_source?: string;
-  graph_name: string;
+  graph_name?: string;
 }
 
 export interface ITaskContentMetadata {


### PR DESCRIPTION
Extraction graph can now be initialized from yaml

```typescript
const graph = ExtractionGraph.fromYaml(`
  name: 'nbakb'
  extraction_policies:
   - extractor: 'tensorlake/chunk-extractor'
     name: 'chunker'
     input_params:
        chunk_size: 1000
        overlap: 100
   - extractor: 'tensorlake/minilm-l6'
     name: 'wikiembedding'
     content_source: 'chunker'
  `);
const resp = await client.createExtractionGraph(graph);
```

Updated tests